### PR TITLE
Add nvtriton install/uninstall/activate scripts

### DIFF
--- a/scripts/INSTALL_NVTRITON_TILEIR.md
+++ b/scripts/INSTALL_NVTRITON_TILEIR.md
@@ -2,25 +2,22 @@
 
 Install nvtriton alongside your existing Triton. OSS Triton is never modified.
 
-## Install
+## Quick Start
 
 ```bash
-bash install_nvtriton.sh                  # default: ~/.local/triton_tileir
-bash install_nvtriton.sh /my/custom/path  # custom location
+bash install_nvtriton.sh                          # install
+source ~/.local/triton_tileir/activate.sh         # activate
+source ~/.local/triton_tileir/deactivate.sh       # deactivate
+bash uninstall_nvtriton.sh                        # uninstall
 ```
 
-## Activate / Deactivate
+## Custom Install Path
 
 ```bash
-source <install_dir>/activate.sh    # enable TileIR backend
-source <install_dir>/deactivate.sh  # revert to OSS Triton
-```
-
-## Uninstall
-
-```bash
-bash uninstall_nvtriton.sh                  # default path
-bash uninstall_nvtriton.sh /my/custom/path  # custom path
+bash install_nvtriton.sh /my/custom/path
+source /my/custom/path/activate.sh
+source /my/custom/path/deactivate.sh
+bash uninstall_nvtriton.sh /my/custom/path
 ```
 
 > Deactivate before uninstalling — the script will remind you if you forget.

--- a/scripts/INSTALL_NVTRITON_TILEIR.md
+++ b/scripts/INSTALL_NVTRITON_TILEIR.md
@@ -1,0 +1,26 @@
+# nvtriton — Triton with TileIR Backend
+
+Install nvtriton alongside your existing Triton. OSS Triton is never modified.
+
+## Install
+
+```bash
+bash install_nvtriton.sh                  # default: ~/.local/triton_tileir
+bash install_nvtriton.sh /my/custom/path  # custom location
+```
+
+## Activate / Deactivate
+
+```bash
+source <install_dir>/activate.sh    # enable TileIR backend
+source <install_dir>/deactivate.sh  # revert to OSS Triton
+```
+
+## Uninstall
+
+```bash
+bash uninstall_nvtriton.sh                  # default path
+bash uninstall_nvtriton.sh /my/custom/path  # custom path
+```
+
+> Deactivate before uninstalling — the script will remind you if you forget.

--- a/scripts/install_nvtriton.sh
+++ b/scripts/install_nvtriton.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Install nvtriton (Triton with TileIR backend) alongside OSS triton.
+# OSS triton is untouched.
+#
+# Usage:
+#   bash install_nvtriton.sh              # installs to ~/.local/triton_tileir
+#   bash install_nvtriton.sh /my/path     # installs to /my/path
+#
+# After install, activate with:
+#   source <install_dir>/activate.sh
+set -euo pipefail
+
+RELEASE_URL="https://github.com/triton-lang/Triton-to-tile-IR/releases/download/v3.6.0-rc1"
+INSTALL_DIR="${1:-${HOME}/.local/triton_tileir}"
+
+PY_TAG=$(python3 -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')")
+WHEEL="nvtriton-3.6.0-${PY_TAG}-${PY_TAG}-linux_x86_64.whl"
+
+echo "==> Detected Python ${PY_TAG}"
+echo "==> Install directory: ${INSTALL_DIR}"
+
+echo "==> Downloading ${WHEEL}..."
+curl -fSL -o "/tmp/${WHEEL}" "${RELEASE_URL}/${WHEEL}"
+
+echo "==> Installing to ${INSTALL_DIR} (OSS triton is untouched)..."
+mkdir -p "${INSTALL_DIR}"
+python3 -m pip install --no-cache-dir --no-deps --target "${INSTALL_DIR}" "/tmp/${WHEEL}"
+rm -f "/tmp/${WHEEL}"
+
+# Generate activate.sh
+cat > "${INSTALL_DIR}/activate.sh" <<EOF
+# Source this file to enable nvtriton TileIR backend.
+#   source ${INSTALL_DIR}/activate.sh
+export PYTHONPATH="${INSTALL_DIR}\${PYTHONPATH:+:\$PYTHONPATH}"
+export ENABLE_TILE=1
+export HELION_BACKEND=tileir
+echo "nvtriton activated."
+EOF
+
+# Generate deactivate.sh
+cat > "${INSTALL_DIR}/deactivate.sh" <<EOF
+# Source this file to revert to OSS triton.
+#   source ${INSTALL_DIR}/deactivate.sh
+if [ -n "\${PYTHONPATH:-}" ]; then
+    PYTHONPATH=\$(echo "\${PYTHONPATH}" | tr ':' '\n' | grep -v "^${INSTALL_DIR}\\\$" | paste -sd ':' || true)
+    [ -z "\${PYTHONPATH}" ] && unset PYTHONPATH || export PYTHONPATH
+fi
+unset ENABLE_TILE
+unset HELION_BACKEND
+echo "nvtriton deactivated. OSS triton is now active."
+EOF
+
+echo ""
+echo "Done! To activate:   source ${INSTALL_DIR}/activate.sh"
+echo "      To deactivate: source ${INSTALL_DIR}/deactivate.sh"
+echo "      To uninstall:  bash uninstall_nvtriton.sh ${INSTALL_DIR}"

--- a/scripts/uninstall_nvtriton.sh
+++ b/scripts/uninstall_nvtriton.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Uninstall nvtriton completely.
+#
+# Usage:
+#   bash uninstall_nvtriton.sh              # removes ~/.local/triton_tileir
+#   bash uninstall_nvtriton.sh /my/path     # removes /my/path
+set -euo pipefail
+
+INSTALL_DIR="${1:-${HOME}/.local/triton_tileir}"
+
+# Check if nvtriton is still active in current shell
+if [ -n "${ENABLE_TILE:-}" ] || [ -n "${HELION_BACKEND:-}" ] || echo "${PYTHONPATH:-}" | grep -q "${INSTALL_DIR}"; then
+    echo "Error: nvtriton is still active. Please deactivate first:"
+    echo "  source ${INSTALL_DIR}/deactivate.sh"
+    exit 1
+fi
+
+if [ -d "${INSTALL_DIR}" ]; then
+    rm -rf "${INSTALL_DIR}"
+    echo "==> Removed ${INSTALL_DIR}"
+else
+    echo "==> ${INSTALL_DIR} not found (already clean)"
+fi
+
+echo "Done!"


### PR DESCRIPTION
Provides opt-in scripts to install nvtriton (Triton with TileIR backend) alongside OSS triton without modifying the existing installation:
- install_nvtriton.sh: downloads and installs to ~/.local/triton_tileir
- uninstall_nvtriton.sh: removes installed files (guards against active env)
- activate.sh/deactivate.sh: generated at install dir for env management
