### PR TITLE
[TileIR] Bump cuda-tile dependency from v13.1.3 to v13.2.0

### DIFF
--- a/third_party/tileir/CMakeLists.txt
+++ b/third_party/tileir/CMakeLists.txt
@@ -43,12 +43,12 @@ else()
     )
     # Track specific tag to avoid breaking change conflict with patch
     execute_process(
-      COMMAND bash -c "git fetch --tags && git checkout v13.1.3"
+      COMMAND bash -c "git fetch --tags && git checkout v13.2.0"
       WORKING_DIRECTORY ${CUDA_TILE_SOURCE_DIR}
       RESULT_VARIABLE CUDA_TILE_CHECKOUT_RESULT
     )
     if(NOT CUDA_TILE_CHECKOUT_RESULT EQUAL 0)
-      message(FATAL_ERROR "Failed to checkout v13.1.3 in ${CUDA_TILE_SOURCE_DIR}")
+      message(FATAL_ERROR "Failed to checkout v13.2.0 in ${CUDA_TILE_SOURCE_DIR}")
     endif()
     if(NOT CUDA_TILE_GIT_CLONE_RESULT EQUAL 0)
       message(FATAL_ERROR "Failed to clone https://github.com/NVIDIA/cuda-tile into ${CUDA_TILE_SOURCE_DIR}")


### PR DESCRIPTION
## Summary
• Bump cuda-tile pin from `v13.1.3` to `v13.2.0` in `third_party/tileir/CMakeLists.txt`
• Fixes build failure for `cuda_tile::Atan2Op` (reported in Helion PR #2028)
• The 13.2 syncup bridge code references `Atan2Op` which is only available in cuda-tile >= 13.2.0

## Changes
• `third_party/tileir/CMakeLists.txt`: 2 lines changed (`git checkout v13.1.3` → `git checkout v13.2.0`)

## Test plan
• Clean build with CTK 13.2 (pytorch:26.03-py3 container) — ✅ compiled successfully
• Phase 1 sanity (TileIRDriver + IR pipeline) — ✅ passed
• Phase 2 tutorials (11/11) — ✅ passed
• Phase 3-7 full test suite — in progress, no failures so far