### PR TITLE
Restore tileir README and add missing ConvertPrintOp lowering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,317 +1,123 @@
+See [The original Triton README](https://github.com/triton-lang/Triton-to-tile-IR/blob/main/README.original.md) for more details.
 
-| **`Documentation`** | **`Nightly Wheels`** |
-|-------------------- | -------------------- |
-| [![Documentation](https://github.com/triton-lang/triton/actions/workflows/documentation.yml/badge.svg)](https://triton-lang.org/) | [![Wheels](https://github.com/triton-lang/triton/actions/workflows/wheels.yml/badge.svg)](https://github.com/triton-lang/triton/actions/workflows/wheels.yml) |
+## ⚡ Helion Hackathon — Performance Tuning Guide
 
-# Triton Conference 2025
+**Default backend is OSS PTX backend(Triton 3.6). Using [Helion](https://github.com/pytorch/helion) with the TileIR backend([whl](https://github.com/triton-lang/Triton-to-tile-IR/releases/download/v3.6.0-rc1/nvtriton-3.6.0-cp313-cp313-linux_x86_64.whl))?** Check out the **[Helion TileIR Backend Performance Tuning Guide](HelionPerformanceTuningGuide.md)** for config recipes, autotuning strategies, and porting tips.
 
-![Triton Banner](https://github.com/user-attachments/assets/b4b6972a-857c-417f-bf2c-f16f38a358c0)
+### ⚠️ How to Submit TileIR Result
 
-The 3rd Triton Developer Conference took place on October 21, 2025 at the Microsoft Silicon Valley Campus in Mountain View, California.
-
-### Conference Materials
-
-Conference recordings and materials are now available online:
-
-- **Conference Videos:** [YouTube Playlist](https://www.youtube.com/playlist?list=PLc_vA1r0qoiQqCdWFDUDqI90oY5EjfGuO)
-- **Conference Slides:** [Google Drive Folder](https://drive.google.com/drive/folders/1KB6tD3UM1J0_eUp-F-JSlGrargLBawIr)
-
-For previous conference materials, see:
-- [2024 Conference Materials](docs/meetups/dev_conference_2024.md)
-- [2023 Conference Materials](docs/meetups/dev-meetup-2023.md)
-
-# Triton
-
-This is the development repository of Triton, a language and compiler for writing highly efficient custom Deep-Learning primitives. The aim of Triton is to provide an open-source environment to write fast code at higher productivity than CUDA, but also with higher flexibility than other existing DSLs.
-
-The foundations of this project are described in the following MAPL2019 publication: [Triton: An Intermediate Language and Compiler for Tiled Neural Network Computations](http://www.eecs.harvard.edu/~htk/publication/2019-mapl-tillet-kung-cox.pdf). Please consider citing this work if you use Triton!
-
-The [official documentation](https://triton-lang.org) contains installation instructions and tutorials.  See also these third-party [Triton puzzles](https://github.com/srush/Triton-Puzzles), which can all be run using the Triton interpreter -- no GPU required.
-
-# Quick Installation
-
-You can install the latest stable release of Triton from pip:
-
-```shell
-pip install triton
-```
-
-Binary wheels are available for CPython 3.10-3.14.
-
-# Install from source
-
-```shell
-git clone https://github.com/triton-lang/triton.git
-cd triton
-
-pip install -r python/requirements.txt # build-time dependencies
-pip install -e .
-```
-
-Or with a virtualenv:
-
-```shell
-git clone https://github.com/triton-lang/triton.git
-cd triton
-
-python -m venv .venv --prompt triton
-source .venv/bin/activate
-
-pip install -r python/requirements.txt # build-time dependencies
-pip install -e .
-```
-
-# Building with a custom LLVM
-
-Triton uses LLVM to generate code for GPUs and CPUs.  Normally, the Triton build
-downloads a prebuilt LLVM, but you can also build and use LLVM from source.
-
-LLVM does not have a stable API, so the Triton build will not work at an
-arbitrary LLVM version.
-
-For convenience, use the following command to build LLVM and install Triton with the custom LLVM:
-
-```shell
-make dev-install-llvm
-```
-
-<details>
-<summary>
-Alternatively, follow these steps to build LLVM from source manually.
-</summary>
-
-1. Find the version of LLVM that Triton builds against.  Check
-`cmake/llvm-hash.txt` to see the current version. For example, if it says:
-       49af6502c6dcb4a7f7520178bd14df396f78240c.
-
-   This means that the version of Triton you have builds against
-   [LLVM](https://github.com/llvm/llvm-project) 49af6502.
-
-2. `git checkout` LLVM at this revision.  Optionally, make additional
-   modifications to LLVM.
-
-3. [Build LLVM](https://llvm.org/docs/CMake.html).  For example, you might run:
-
-       $ cd $HOME/llvm-project  # your clone of LLVM.
-       $ mkdir build
-       $ cd build
-       $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON ../llvm -DLLVM_ENABLE_PROJECTS="mlir;llvm;lld" -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU"
-       $ ninja
-
-4. Grab a snack, this will take a while.
-
-5. Build Triton as above, but set the following environment variables:
-
-       # Modify as appropriate to point to your LLVM build.
-       $ export LLVM_BUILD_DIR=$HOME/llvm-project/build
-
-       $ cd <triton install>
-       $ LLVM_INCLUDE_DIRS=$LLVM_BUILD_DIR/include \
-         LLVM_LIBRARY_DIR=$LLVM_BUILD_DIR/lib \
-         LLVM_SYSPATH=$LLVM_BUILD_DIR \
-         pip install -e .
-
-</details>
-
-# Tips for building
-
-- Set `TRITON_BUILD_WITH_CLANG_LLD=true` as an environment variable to use clang
-  and lld.  lld in particular results in faster builds.
-
-- Set `TRITON_BUILD_WITH_CCACHE=true` to build with ccache.
-
-- Set `TRITON_HOME=/some/path` to change the location of the `.triton`
-  directory where Triton's cache is located and downloads are stored
-  during the build. By default, this is the user's home directory. It
-  can be changed anytime.
-
-- If you're running out of memory when building Triton, specify the `MAX_JOBS`
-  environment variable (to the `pip install -e .` command) to limit the
-  number of jobs.
-
-- Pass `--no-build-isolation` to `pip install` to make nop builds faster.
-  Without this, every invocation of `pip install` uses a different symlink to
-  cmake, and this forces ninja to rebuild most of the `.a` files.
-
-- The build system creates a `compile_commands.json` file under the Triton repo
-  directory. This file is used by VSCode IntelliSense and clangd to provide
-  code completion and other features for C++ code.
-
-  If IntelliSense does not work, you can try the following steps:
-
-    - Do a local build. Run command `pip install -e .`.
-    - Get the full path to the `compile_commands.json` file produced by the build:
-      `find ./build -name 'compile_commands.json' | xargs readlink -f`.
-      You might get a full path similar to `/Users/{username}/triton/build/cmake.macosx-11.1-arm64-cpython-3.12/compile_commands.json`.
-    - In VSCode, install the
-      [C/C++
-      extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools),
-      then open the command palette (`Shift + Command + P` on Mac, or `Shift +
-      Ctrl + P` on Windows/Linux) and open `C/C++: Edit Configurations (UI)`.
-    - Open "Advanced Settings" and paste the full path to
-      `compile_commands.json` into the "Compile Commands" textbox.
-
-# Running tests
-
-There currently isn't a turnkey way to run all the Triton tests, but you can
-follow the following recipe:
-
-```shell
-# One-time setup.  Note this will reinstall local Triton because torch
-# overwrites it with the public version.
-$ make dev-install
-
-# To run all tests (requires a GPU)
-$ make test
-
-# Or, to run tests without a gpu
-$ make test-nogpu
-```
-
-# Tips for hacking
-
-For detailed instructions on how to debug Triton's frontend, please refer to this [tutorial](https://triton-lang.org/main/programming-guide/chapter-3/debugging.html). The following includes additional tips for hacking on Triton's backend.
-
-**Configuration knobs**
-
-See [`python/triton/knobs.py`](python/triton/knobs.py) for the full list of configuration knobs. You can set those knobs directly in python or use environment variables to control them. Below are some of the environment variables you can specify (see `knobs.py` for the full list):
-
-- `MLIR_ENABLE_DUMP=1` dumps the IR before every MLIR pass Triton runs, for all
-   kernels. Use `MLIR_ENABLE_DUMP=kernelName` to dump for a specific kernel only.
-  - Triton cache can interfere with the dump. In cases where `MLIR_ENABLE_DUMP=1` does not work, try cleaning your triton cache: `rm -r ~/.triton/cache/*`.
-- `MLIR_DUMP_PATH` specifies where `MLIR_ENABLE_DUMP` will dump to. If unset will dump to stderr.
-- `LLVM_IR_ENABLE_DUMP=1` dumps the IR before every pass run over the LLVM IR.
-- `TRITON_REPRODUCER_PATH=<reproducer_path>` will generate an MLIR reproducer file
-  at `<reproducer_path>` before each MLIR compiler stage. If any of the stages fail,
-  `<reproducer_path>` will be a local MLIR reproducer captured right before the failing pass.
-- `TRITON_INTERPRET=1` uses the Triton interpreter instead of running on the
-  GPU.  You can insert Python breakpoints in your kernel code!
-- `TRITON_ENABLE_LLVM_DEBUG=1` passes `-debug` to LLVM, printing a lot of
-  debugging information to stdout.  If this is too noisy, run with just
-  `TRITON_LLVM_DEBUG_ONLY` instead to limit the output.
-  - An alternative way to reduce output noisiness is running with
-  `LLVM_IR_ENABLE_DUMP=1`, extract the IR before the LLVM pass of interest, and
-  then run LLVM's `opt` standalone, perhaps passing `-debug-only=foo` on the
-  command line.
-
-- `TRITON_LLVM_DEBUG_ONLY=<comma-separated>` is the equivalent of LLVM's
-  `-debug-only` command-line option. This limits the LLVM debug output to
-  specific pass or component names (which are specified using `#define
-  DEBUG_TYPE` throughout LLVM and Triton) in order to allow the debug output to
-  be less noisy. `TRITON_LLVM_DEBUG_ONLY` allows for one or more comma
-  separated values to be specified (eg
-  `TRITON_LLVM_DEBUG_ONLY="tritongpu-remove-layout-conversions"` or
-  `TRITON_LLVM_DEBUG_ONLY="tritongpu-remove-layout-conversions,regalloc"`).
-- `TRITON_ENABLE_ASAN=1` invokes the LLVM address sanitizer for
-  memory leak and out of bounds access detection. Currently only supported on the AMD
-  backend. This must be run using the ASAN libraries documented [here](https://rocm.docs.amd.com/projects/llvm-project/en/latest/conceptual/using-gpu-sanitizer.html).
-  - When enabling the address sanitizer it is recommended to disable various memory caching strategies
-  both within the ROCm stack and PyTorch. This will give the address sanitizer the best chance at finding the
-  memory fault where it originates. See this [test](https://github.com/triton-lang/triton/blob/main/third_party/amd/python/test/test_address_sanitizer.py) for more details.
-
-- `USE_IR_LOC={ttir,ttgir}` reparses the IR such that the location information
-  will be the line number of the IR file with that particular extension,
-  instead of line number of the python file. This can provide a direct mapping
-  from the IR to llir/ptx. When used with performance tools, it can provide a
-  breakdown on IR instructions.
-- `TRITON_PRINT_AUTOTUNING=1` prints out the best autotuning config and total time
-  spent for each kernel after autotuning is complete.
-- `DISABLE_LLVM_OPT` will disable llvm optimizations for make_llir and make_ptx
-  if its value is true when parsing as Bool. Otherwise, it will be parsed as a list
-  of flags to disable llvm optimizations. One usage case is
-  `DISABLE_LLVM_OPT="disable-lsr"`
-  Loop strength reduction is known to cause up to 10% performance changes for
-  certain kernels with register pressure.
-- `TRITON_ALWAYS_COMPILE=1` forces to compile kernels regardless of cache hit.
-- `MLIR_ENABLE_TIMING` dumps the timing information for each MLIR pass.
-- `LLVM_ENABLE_TIMING` dumps the timing information for each LLVM pass.
-- `TRITON_DEFAULT_FP_FUSION` overrides the default behavior of allowing fp fusion (mul+add->fma).
-- `MLIR_ENABLE_DIAGNOSTICS=<comma-separated>` controls diagnostic emission in MLIR.
-  Options are: `warnings`, `remarks`, `stacktraces`, `operations`.
-  Use comma-separated values to customize output. For example,
-  `MLIR_ENABLE_DIAGNOSTICS=remarks,operations` enables remarks and IR operations,
-  while `MLIR_ENABLE_DIAGNOSTICS=warnings,stacktraces` enables warnings with
-  stacktraces. By default, only errors are shown. Setting `warnings` includes
-  errors and warnings; `remarks` includes errors, warnings, and remarks.
-- `MLIR_ENABLE_REMARK` is deprecated. Please use `MLIR_ENABLE_DIAGNOSTICS=remarks`.
-- `TRITON_KERNEL_DUMP` enables the dumping of the IR from each compilation stage and the final ptx/amdgcn.
-- `TRITON_DUMP_DIR` specifies the directory to save the dumped IR and ptx/amdgcn when `TRITON_KERNEL_DUMP` is set to 1.
-- `TRITON_KERNEL_OVERRIDE` enables the override of the compiled kernel with a user-specified IR/ptx/amdgcn at the beginning of each compilation stage.
-- `TRITON_OVERRIDE_DIR` specifies the directory from which to load the IR/ptx/amdgcn files when `TRITON_KERNEL_OVERRIDE` is set to 1.
-- `TRITON_F32_DEFAULT` sets the default input precision of `tl.dot` when using 32-bit floats, which can be either `ieee`, `tf32`, or `tf32x3`.
-- `TRITON_FRONT_END_DEBUGGING=1` disables exception wrapping when an error occurs in the compiler frontend, allowing the full stack trace to be seen.
-- `TRITON_DISABLE_LINE_INFO=1` removes all line information from the module.
-- `PTXAS_OPTIONS` passes additional command-line options to the PTX assembler `ptxas` (only on NVIDIA).
-- `LLVM_EXTRACT_DI_LOCAL_VARIABLES` emit full debug info, allowing for eval of values in gpu debuggers (ie cuda-gdb, rocm-gdb etc)
-- `TRITON_DEFAULT_BACKEND=<backend>` optionally sets the default backend used by Triton when
-  constructing the active driver (i.e., `triton.runtime.driver.active`).
-
-> [!NOTE]
-> Some of these environment variables don't have a knob in `knobs.py`-- those are only relevant to the C++ layer(s), hence they don't exist in the python layer.
-
-**Kernel Override Steps**
-
-```bash
-export TRITON_ALWAYS_COMPILE=1
-export TRITON_KERNEL_DUMP=1
-export TRITON_DUMP_DIR=<dump_dir>
-export TRITON_KERNEL_OVERRIDE=1
-export TRITON_OVERRIDE_DIR=<override_dir>
-# Step 1: Run the kernel once to dump kernel's IRs and ptx/amdgcn in $TRITON_DUMP_DIR
-# Step 2: Copy $TRITON_DUMP_DIR/<kernel_hash> to $TRITON_OVERRIDE_DIR
-# Step 3: Delete the stages that you do not want to override and modify the stage you do want to override
-# Step 4: Run the kernel again to see the overridden result
-```
-
-**Compiler Pipeline Inspection Steps**
-To introspect the pipeline `add_stages`, before running your kernels, simply set
-the add_stages_inspection_hook like so:
+> **You MUST set both `ENABLE_TILE=1` and `HELION_BACKEND=tileir` via `os.environ` at the top of your `submission.py`, before any `import helion` or `import triton` statements.** These environment variables must be set before the modules are imported to take effect.
 
 ```python
-def inspect_stages(_self, stages, options, language, capability):
-    # inspect or modify add_stages here
-triton.knobs.runtime.add_stages_inspection_hook = inspect_stages
+import os
+os.environ["ENABLE_TILE"] = "1"
+os.environ["HELION_BACKEND"] = "tileir"
+
+# Now import helion/triton — they will pick up the TileIR backend
+import helion
+import helion.language as hl
+
+# ... rest of your submission code ...
 ```
-Examples of how to use this for out of tree plugin passes is [here](lib/Plugins/README.md)
-# Changelog
 
-Version 2.0 is out! New features include:
+### Troubleshooting: Porting Configs from Triton Backend
 
-- Many, many bug fixes
-- Performance improvements
-- Backend rewritten to use MLIR
-- Support for kernels that contain back-to-back matmuls (e.g., flash attention)
+> **Do NOT directly reuse Helion configs tuned for the Triton (PTX) backend.** The two backends have different tuning knobs with different semantics — directly porting configs will likely result in poor performance or tuning errors like below
 
-# Contributing
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `InvalidConfig: Too many values for config['range_unroll_factors']` | tileir doesn't support `range_*` params | Remove `range_flattens`, `range_multi_buffers`, `range_num_stages`, `range_unroll_factors`, `range_warp_specializes`, `static_ranges` |
+| `InvalidConfig: Too many values for config['static_ranges']` | Same as above | Same — remove all `range_*` and `static_ranges` |
 
-Community contributions are more than welcome, whether it be to fix bugs or to add new features at [github](https://github.com/triton-lang/triton/). For more detailed instructions, please visit our [contributor's guide](CONTRIBUTING.md).
+- **Remove unsupported knobs**: TileIR does not support `range_unroll_factors`, `range_multi_buffers`, `range_flattens`, `range_warp_specialize`, `load_eviction_policies`, `static_ranges`, `indexing="block_ptr"`, etc. See the full list in the [Helion TileIR Performance Tuning Guide](HelionPerformanceTuningGuide.md#knobs-not-available-on-tileir). If you want to try the TileIR backend with default-backend-tuned config, remember to remove the unsupported configs.
+- **Recommended**: Start autotuning from scratch. The TileIR backend has its own set of knobs (`occupancy`, `num_ctas`, wider `num_stages` range) and the autotuner will explore them effectively.
 
-# Compatibility
+**Triton-TileIR backend general optimization tips?** See the **[Performance Tuning Tips](third_party/tileir/PerformanceTuningTips.md)** for occupancy, num_ctas, TMA API preferences, num_stages tuning, and benchmark results.
 
-Supported Platforms:
+---
 
-- Linux
+# Triton CUDA Tile IR Backend
+This incubator repo adds the CUDA Tile IR backend to Triton. Users can enable the CUDA Tile IR backend by setting the environment variable `ENABLE_TILE=1`. The CUDA Tile IR backend in this repo only uses features available in CUDA 13.1.
 
-Supported Hardware:
+## How to install?
+doesn't change
+```
+pip install -e .
+```
 
-- NVIDIA GPUs (Compute Capability 8.0+)
-- AMD GPUs (ROCm 6.2+)
-- Under development: CPUs
+## How to run CUDA Tile IR Backend?
 
-# Development Container (Dev Container)
+```bash
+export ENABLE_TILE=1
+```
 
-**Dev Containers** for the Triton project are available from
-the [triton-dev-containers repository](https://github.com/redhat-et/triton-dev-containers).
+## Known functional issues
 
-### Key Benefits:
-- **Consistency**: All developers can work with the same development
-  environment, ensuring uniform behavior across different systems.
-- **Isolation**: The container prevents potential conflicts with software
-  installed on your local machine.
-- **Portability**: Easily share the development environment with team members,
-  minimizing onboarding time and setup issues.
+CUDA Tile IR now supports only an unordered memory model, where global memory access operations are not ordered by default. If explicit memory access ordering is required, memory token semantics are available for users to control this behavior.
+Currently, the implementation includes only APIs that are compatible with existing Triton APIs for current Triton kernels. Support for memory tokens will require extending the Triton APIs. We plan to submit another MR to extend Triton APIs for the CUDA Tile memory model later.
+At this stage, the following workloads may produce incorrect results unless the script is updated:
 
-### How to Use the Dev Container:
+- When there is memory aliasing between different global memory access operations.
+- When data transactions occur across different tile blocks (e.g., splitK/streamK), where deterministic reduction across tile blocks requires lock logic in global memory.
 
-For detailed instructions on how to use the dev containers, please see
-the [dev container user guide](https://github.com/redhat-et/triton-dev-containers/blob/main/.devcontainer/devcontainer.md).
+Potential future solutions (to be discussed):
+
+- Extend Triton APIs to explicitly support the unordered memory model (scripts will need revision).
+- Abstract global memory locks into an independent API.
+- Apply conservative rules to append memory tokens during Triton-to-CUDA Tile conversion, which avoids script changes but may introduce performance loss.
+
+## Known performance issues
+- Small GEMM performance is currently poor (will be addressed in a future CUDA release).
+- Kernels using legacy tensor-of-pointer load/store APIs exhibit poor performance (will be addressed in a future CUDA release).
+- `num_warps` is not exposed yet. For XXXNorm kernels with large reduction dimensions, performance may degrade due to register spilling (support may be added in a future CUDA release).
+
+## Performance Tuning Tips
+- New hints for CUDA Tile IR backend: `occupancy` (critical). The occupancy hint accepts an integer N from 1 to 32, indicating that the programmer expects N active thread blocks to run simultaneously per SM. This hint is 1 by default and is worth tuning for many compute-intensive kernels.
+- Existing Triton hints: `num_ctas` (critical). Setting `num_ctas=2` is critical for dense dot-related workloads, as it enables 2CTA mode MMA on Blackwell architecture.
+- For guidance on performance tuning, please refer to the detailed tips provided [here](third_party/tileir/PerformanceTuningTips.md).
+
+## ChangeList
+### Triton’s core files changes:
+
+1. When `ENABLE_TILE=1` is set, the default CUDA target is switched to the CUDA Tile IR target. Changes are made to `driver.py` and `compiler.py`.
+2. When a compilation bug occurs with the CUDA Tile IR Backend, it falls back to the NVIDIA PTX backend. Main changes include `jit.py` and `nvidia/backend/driver.py`.
+3. Support for lowering Triton host TMA APIs to CUDA Tile IR's TMA APIs. Triton provides both host and device TMA implementations, but CUDA TileIR only has the device implementation (internally, the CUDA Tile IR compiler determines whether to use host or device; however, in the language, only the kernel-level API exists). Main files modified: `core.py`, `semantic.py`, `tensor_descriptor.py`.
+4. CUDA Tile IR disables approx by default. To enable approx, pls use `export TILEIR_ENABLE_APPROX=1`
+5. CUDA Tile IR disables FTZ by default. To enable FTZ , pls use `export TILEIR_ENABLE_FTZ=1`
+
+### CUDA Tile IR Backend support:
+
+1. Conversion pass: converts TTIR to CUDA Tile IR. Implemented in `TritonToCudaTile.*`
+2. Rewrite assume pass: converts assume ops in TTIR/LLVM IR to CUDA Tile IR assume ops. Implemented in `rewriteAssume.*`
+3. Python code: mostly aligned with `third_party/nvidia/backend`.
+ 
+## CUDA Tile IR in CUDA 13.1
+We only support Blackwell GPU in CUDA 13.1.
+### Dependency
+Triton CUDA Tile IR backend depends on `bin/tileiras`, `bin/ptxas`, and `nvvm/lib64/libnvvm.so` from CUDA 13.1.
+Triton CUDA Tile IR backend also depends on the [CUDA Tile IR dialect](https://github.com/NVIDIA/cuda-tile).
+
+### Auto Tune
+CUDA Tile IR in CUDA 13.1 doesn't support `num_warps` (but may support it in a future CUDA release), while CUDA Tile IR adds a new tuning attribute `occupancy`. **In practice, we have found that `occupancy` and `num_ctas` are crucial to CUDA Tile IR performance.**
+
+### Operations and features not yet supported or fully supported:
+- `tt.elementwise_inline_asm`
+- `cf.cond_br`
+- `cuda_tile.reduce` (only pure operations allowed)
+- `tt.gather`
+- `tt.unsplat`
+- `tt.dot_scaled`
+- `cuda_tile.ftof` (rtz mode not supported)
+- `tt.extern_elementwise`
+- `tt.map_elementwise`
+- TMA scatter feature
+- TMA gather feature
+- TMA reduce feature
+- TMA load padding default value
+- `math.erf`
+- `atomic_rmw` (bf16 dtype not supported)
+- `atomic_cas` (bf16 and fp16 not supported)
+- TMA rmw feature
+- TMA arbitrary offset is not supported yet
+- i64 index type of the memref is not supported yet
+

--- a/third_party/tileir/lib/TritonToTileIR/TritonToTileIRPass.cpp
+++ b/third_party/tileir/lib/TritonToTileIR/TritonToTileIRPass.cpp
@@ -199,6 +199,37 @@ public:
   }
 };
 
+class ConvertPrintOp : public OpConversionPattern<triton::PrintOp> {
+public:
+  using OpConversionPattern<triton::PrintOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::PrintOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto prefix = op.getPrefix().str();
+    auto args = adaptor.getArgs();
+    std::string newPrefix = prefix;
+    for (Value arg : args) {
+      auto tileType = cast<cuda_tile::TileType>(arg.getType());
+      Type elType = tileType.getElementType();
+      if (isa<IntegerType>(elType)) {
+        newPrefix += "%i";
+      } else if (isa<FloatType>(elType)) {
+        newPrefix += "%.5f";
+      } else if (isa<cuda_tile::PointerType>(elType)) {
+        newPrefix += "%p";
+      } else {
+        llvm::report_fatal_error("unsupported type");
+      }
+    }
+    newPrefix += "\n";
+
+    cuda_tile::PrintTkoOp::create(rewriter, op.getLoc(), newPrefix, args,
+                                           /*token=*/Value());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
 
 class ConvertLoadOp : public OpConversionPattern<triton::LoadOp> {
 public:
@@ -2388,6 +2419,7 @@ void populateTTirToCudaTileConversionPatternsAndLegality(
     ConvertMaximumFOp,
     ConvertMinNumFOp,
     ConvertMinimumFOp,
+    ConvertPrintOp,
     ConvertReduceOp,
     ConvertReduceReturnOp,
     ConvertReshapeOp,


### PR DESCRIPTION
## Summary
• Restored the tileir backend README that was overwritten by the upstream OAIT README during the 13.2 merge
• Added missing `ConvertPrintOp` pattern to `TritonToTileIRPass.cpp` — fixes `failed to legalize operation 'tt.print'` when using `tl.device_print` with the tileir backend

## Root Cause
`ConvertPrintOp` was wrapped in `nv-triton-internal-version-begin dev` markers in the source, which were stripped during the release process. This left `tt.print` with no lowering pattern in the public build.

## Test Plan
• Verified build succeeds on GB100 (pytorch:26.03-py3, CTK 13.2)
• Verified `tl.device_print` with multiple tensor args produces correct output:
```
 unpacked values: [[1.00000, 2.00000]][[5.00000, 6.00000]][[9.00000, 10.00000]]
 unpacked tuple: [[2.00000, 3.00000]][[6.00000, 7.00000]][[10.00000, 11.00000]]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)