### PR TITLE
[TileIR] Bump cuda-tile to v13.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ cuobjdump
 nvdisasm
 ptxas
 ptxas-blackwell
+tileiras
 
 # Third-party include
 third_party/nvidia/backend/include

--- a/cmake/nvidia-toolchain-version.json
+++ b/cmake/nvidia-toolchain-version.json
@@ -6,5 +6,6 @@
   "cudacrt": "13.1.80",
   "cudart": "13.1.80",
   "cupti": "12.8.90",
-  "cupti-blackwell": "13.0.85"
+  "cupti-blackwell": "13.0.85",
+  "tileiras": "13.3.36"
 }

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -51,6 +51,7 @@ class BuildHelperArgs:
     cupti_include_path: Optional[str]
     cupti_lib_path: Optional[str]
     cupti_lib_blackwell_path: Optional[str]
+    tileiras_path: Optional[str]
 
 
 def _normalize_bool(value: str, default: str = "") -> bool:
@@ -413,6 +414,17 @@ def download_and_copy_dependencies(helper_args: BuildHelperArgs):
         f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_cupti/{system}-{arch}/cuda_cupti-{system}-{arch}-{version}-archive.tar.xz",
         helper_args=helper_args,
     )
+    download_and_copy(
+        name="tileiras",
+        src_func=lambda system, arch, version:
+        f"cuda_tileiras-{system}-{arch}-{version}-archive/bin/tileiras{exe_extension}",
+        dst_path="bin/tileiras",
+        override_path=helper_args.tileiras_path,
+        version=nvidia_toolchain_version["tileiras"],
+        url_func=lambda system, arch, version:
+        f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_tileiras/{system}-{arch}/cuda_tileiras-{system}-{arch}-{version}-archive.tar.xz",
+        helper_args=helper_args,
+    )
 
 
 def add_common_args(parser: argparse.ArgumentParser):
@@ -439,6 +451,8 @@ def add_common_args(parser: argparse.ArgumentParser):
     parser.add_argument("--triton-cupti-lib-path", default="", help="Path override for TRITON_CUPTI_LIB_PATH")
     parser.add_argument("--triton-cupti-lib-blackwell-path", default="",
                         help="Path override for TRITON_CUPTI_LIB_BLACKWELL_PATH")
+    parser.add_argument("--triton-tileiras-path", default="",
+                        help="Path override for TRITON_TILEIRAS_PATH")
 
 
 def normalize_parsed_args(parsed_args) -> BuildHelperArgs:
@@ -457,6 +471,7 @@ def normalize_parsed_args(parsed_args) -> BuildHelperArgs:
         cupti_include_path=_normalize_optional_path(parsed_args.triton_cupti_include_path),
         cupti_lib_path=_normalize_optional_path(parsed_args.triton_cupti_lib_path),
         cupti_lib_blackwell_path=_normalize_optional_path(parsed_args.triton_cupti_lib_blackwell_path),
+        tileiras_path=_normalize_optional_path(parsed_args.triton_tileiras_path),
     )
 
 

--- a/third_party/tileir/CMakeLists.txt
+++ b/third_party/tileir/CMakeLists.txt
@@ -35,7 +35,7 @@ else()
 
     # Clone then fetch the pinned commit (--depth 1 alone only gets default branch tip;
     # we need this exact commit for patch compatibility).
-    set(CUDA_TILE_COMMIT 0859212ad19f71133a9b940c05323286cbf28a05)
+    set(CUDA_TILE_COMMIT 2e5ccba66fb3afdba34b26cf358418283027c248)
     execute_process(
       COMMAND bash -c "git clone --depth 1 https://github.com/NVIDIA/cuda-tile tileir_src && cd tileir_src && git fetch --depth 1 origin ${CUDA_TILE_COMMIT} && git checkout FETCH_HEAD"
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -43,12 +43,12 @@ else()
     )
     # Track specific tag to avoid breaking change conflict with patch
     execute_process(
-      COMMAND bash -c "git fetch --tags && git checkout v13.2.0"
+      COMMAND bash -c "git fetch --tags && git checkout v13.3.0"
       WORKING_DIRECTORY ${CUDA_TILE_SOURCE_DIR}
       RESULT_VARIABLE CUDA_TILE_CHECKOUT_RESULT
     )
     if(NOT CUDA_TILE_CHECKOUT_RESULT EQUAL 0)
-      message(FATAL_ERROR "Failed to checkout v13.2.0 in ${CUDA_TILE_SOURCE_DIR}")
+      message(FATAL_ERROR "Failed to checkout v13.3.0 in ${CUDA_TILE_SOURCE_DIR}")
     endif()
     if(NOT CUDA_TILE_GIT_CLONE_RESULT EQUAL 0)
       message(FATAL_ERROR "Failed to clone https://github.com/NVIDIA/cuda-tile into ${CUDA_TILE_SOURCE_DIR}")

--- a/third_party/tileir/backend/conf.py
+++ b/third_party/tileir/backend/conf.py
@@ -25,18 +25,32 @@ class TileIREnvConf:
 
     @staticmethod
     def get_tileiras_path():
+        # Resolution order: explicit env override > bundled binary > system PATH.
         env_path = os.getenv("TRITON_TILEIRAS_PATH", None)
-        if env_path is None:
-            # Check if tileiras exists in system PATH
-            from shutil import which
+        if env_path is not None:
+            return os.path.join(env_path, "tileiras")
 
-            tileiras_path = which("tileiras")
-            if tileiras_path is None:
-                raise RuntimeError(
-                    "tileiras not found in PATH and TRITON_TILEIRAS_PATH not set"
-                )
-            return tileiras_path
-        return os.path.join(env_path, "tileiras")
+        # Bundled binary downloaded at build time into the nvidia backend.
+        bundled_path = os.path.join(
+            os.path.dirname(triton.__file__),
+            "backends",
+            "nvidia",
+            "bin",
+            "tileiras",
+        )
+        if os.path.isfile(bundled_path) and os.access(bundled_path, os.X_OK):
+            return bundled_path
+
+        # Fall back to system PATH.
+        from shutil import which
+
+        tileiras_path = which("tileiras")
+        if tileiras_path is None:
+            raise RuntimeError(
+                "tileiras not found: TRITON_TILEIRAS_PATH unset, no bundled "
+                "binary, and not in PATH"
+            )
+        return tileiras_path
 
     @staticmethod
     def get_device():


### PR DESCRIPTION
- CMakeLists: pin cuda-tile source to v13.3.0 (commit 2e5ccba)
- build_helpers.py: download_and_copy tileiras from CDN (cuda_tileiras redist)
  + BuildHelperArgs.tileiras_path + --triton-tileiras-path override
- cmake/nvidia-toolchain-version.json: add tileiras 13.3.36 (cupti-blackwell preserved)
- conf.py get_tileiras_path: env override > bundled binary > system PATH
- .gitignore: ignore the downloaded tileiras binary

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
